### PR TITLE
add requirements/locks readme

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v4.0.1'
+    rev: 'v4.4.0'
     hooks:
         # Prevent giant files from being committed.
     -   id: check-added-large-files
@@ -17,24 +17,25 @@ repos:
         # Don't commit to master branch.
     -   id: no-commit-to-branch
 -   repo: https://github.com/psf/black
-    rev: '21.6b0'
+    rev: '23.1.0'
     hooks:
     -   id: black
-        # Force black to run on whole repo, using settings from pyproject.toml
-        pass_filenames: false
+        types: [file, python]
         args: [--config=./pyproject.toml, .]
 -   repo: https://github.com/PyCQA/flake8
-    rev: '3.9.2'
+    rev: '6.0.0'
     hooks:
         # Run flake8.
     -   id: flake8
         args: [--config=./.flake8]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.1
+    rev: '5.12.0'
     hooks:
     -   id: isort
         name: isort (python)
-        args: ["--profile", "black", "--filter-files"]
+        types: [file, python]
+        args: [--filter-files]
     -   id: isort
         name: isort (cython)
-        types: [cython]
+        types: [file, cython]
+        args: [--filter-files]

--- a/requirements/locks/README.md
+++ b/requirements/locks/README.md
@@ -1,0 +1,3 @@
+This directory contains auto-generated `conda-lock` environment files for each `python` distribution supported by `python-stratify`.
+
+Please do not manually edit these files as they will be overritten by the GHA CI workflow.


### PR DESCRIPTION
This PR adds a developer `README.md` to the new `requirements/locks` directory.

The `README.md` is a means to create the directory required by the GHA reusable workflow to create `conda-lock` environment files for its CI auto-generated pull-requests.

Also, I updated the versions of the `pre-commit` git-hooks, as the older version of `isort` was hitting a known `poetry` issue that has been resolved in more recent versions.