### PR TITLE
moving the pytest configuration from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ exclude = '''
 profile = "black"
 skip_gitignore = "True"
 verbose = "True"
+
+[tool.pytest.ini_options]
+addopts = "-ra -v --doctest-modules"
+testpaths = ["stratify/"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,12 +48,3 @@ dev =
     codecov
 release =
     twine
-
-[tool:pytest]
-testpaths =
-    stratify/
-addopts =
-    -ra
-    -v
-    --doctest-modules
-doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS NUMBER


### PR DESCRIPTION
Part of the MVP for the next release.

I have updated the pyproject.toml to include the pytest configuration and subsequently removed it from the setup.cfg.

I also found the 'doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS NUMBER' unnecessary as with or without it all of the tests run and pass. I have removed it only to be returned if or when it becomes required.

closes #66 

