### PR TITLE
use refresh-lockfiles version

### DIFF
--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -14,5 +14,5 @@ on:
 
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@main
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.0
     secrets: inherit


### PR DESCRIPTION
This PR uses the explicit `SciTools/workflows` release version.