### PR TITLE
use ci-manifest reusable workflow

### DIFF
--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -10,7 +10,7 @@ on:
 
   push:
     branches-ignore:
-      - "conda-lock-auto-update"
+      - "auto-update-lockfiles"
       - "pre-commit-ci-update-config"
       - "dependabot/*"
 
@@ -23,18 +23,4 @@ concurrency:
 jobs:
   manifest:
     name: "check-manifest"
-
-    runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        shell: bash -l {0}
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: "check-manifest"
-        run: |
-          pipx run check-manifest
+    uses: scitools/workflows/.github/workflows/ci-manifest.yml@2023.03.3

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -12,7 +12,11 @@ on:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onschedule
     - cron: "3 0 * * 6"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.0
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.3
     secrets: inherit


### PR DESCRIPTION
This PR uses the new `scitool/workflows` `ci-manifest` reuseable GHA.

Reference:
- https://github.com/SciTools/workflows/pull/21 