### PR TITLE
update to latest workflows version

### DIFF
--- a/.github/workflows/ci-manifest.yml
+++ b/.github/workflows/ci-manifest.yml
@@ -23,4 +23,4 @@ concurrency:
 jobs:
   manifest:
     name: "check-manifest"
-    uses: scitools/workflows/.github/workflows/ci-manifest.yml@2023.03.3
+    uses: scitools/workflows/.github/workflows/ci-manifest.yml@2023.04.1

--- a/.github/workflows/refresh-lockfiles.yml
+++ b/.github/workflows/refresh-lockfiles.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   refresh_lockfiles:
-    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.03.3
+    uses: scitools/workflows/.github/workflows/refresh-lockfiles.yml@2023.04.1
     secrets: inherit


### PR DESCRIPTION
This PR bumps the reusable workflows version, which includes the fix to `ci-manifest` regarding concurrency, see https://github.com/SciTools/workflows/pull/23