### PR TITLE
Setting up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Reference:
+#   - https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+    labels:
+      - "New: Pull Request"
+      - "Bot"


### PR DESCRIPTION
Adding a config file to support dependabot for stratify.

This should check dependency versions daily and create pull requests to update them to the latest versions.