### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Discover the capabilities of `stratify` with this introductory [Jupyter Notebook
 ## Installation
 
 ```shell
-conda install -c conda-forge python-stratify
+conda install --channel conda-forge python-stratify
 ```
 ```shell
-pip install python-stratify
+pip install stratify
 ```
 
 ## License


### PR DESCRIPTION
This PR makes a slight tweak to the `README.md` i.e., it's `pip install stratify` not `pip install python-stratify` :wink: 