### PR TITLE
parallel macos wheels

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -24,25 +24,34 @@ on:
 
 jobs:
   build_bdist:
-    name: "build ${{ matrix.os }} wheels"
+    name: "build ${{ matrix.os }} (${{ matrix.arch }}) wheels"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        arch: ["x86_64", "arm64"]
+        exclude:
+          - os: "ubuntu-latest"
+            arch: "arm64"
+          - os: "windows-latest"
+            arch: "x86_64"
+          - os: "windows-latest"
+            arch: "arm64"
+        include:
+          - os: "windows-latest"
+            arch: "AMD64"
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: "build ${{ matrix.os }} wheels"
+    - name: "build ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v2.12.3
       env:
         CIBW_SKIP: "cp36-* cp37-* pp* *-musllinux*"
-        CIBW_ARCHS_LINUX: "x86_64"
-        CIBW_ARCHS_MACOS: "x86_64 arm64"
-        CIBW_ARCHS_WINDOWS: "AMD64"
+        CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD_FRONTEND: "build"
         CIBW_MANYLINUX_X86_64_IMAGE: "manylinux2014"
         CIBW_TEST_SKIP: "*-macosx_arm64"


### PR DESCRIPTION
This PR makes the `macos` binary wheels build parallel, and thus roughly halving the overall runtime of `ci-wheels`.