### PR TITLE
fix typo

### DIFF
--- a/requirements/locks/README.md
+++ b/requirements/locks/README.md
@@ -1,3 +1,5 @@
+# ⚠️
+
 This directory contains auto-generated `conda-lock` environment files for each `python` distribution supported by `python-stratify`.
 
-Please do not manually edit these files as they will be overritten by the GHA CI workflow.
+Please **do not** manually edit these files as they will be overwritten by the GHA CI workflow.


### PR DESCRIPTION
This PR fixes a minor typo on the `requirements/locks/README.md`.