### PR TITLE
fixing a couple of bugs with the labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@
   - '(testing|tests|coverage|Testing|Tests|Coverage)'
 
 'Type: Bug':
-  - '(bug|patch|fix|Bug|Fix|Patch)'
+  - '(bug|Bug)'
 
 'Type: Enhancement':
   - '(feature|Feature)'

--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -25,4 +25,3 @@ jobs:
           enable-versioned-regex: 0
           include-title: 1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          sync-labels: 1


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

There is a bug where because of sync labels it was removing the GHA tag from issues and pr's. This should fix that. Also there were instances where the bug label was incorrectly added so I have slimmed down the regex targets.

---
