### PR TITLE
change references from master to main

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -14,7 +14,7 @@ on:
 
   push:
     branches:
-      - "master"
+      - "main"
       - "v*x"
       - "!auto-update-lockfiles"
       - "!pre-commit-ci-update-config"
@@ -103,8 +103,8 @@ jobs:
     needs: [build_bdist, build_sdist]
     name: "Publish to Test PyPI"
     runs-on: ubuntu-latest
-    # upload to Test PyPI for every commit on master branch
-    if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+    # upload to Test PyPI for every commit on main branch
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/main'
     steps:
     - uses: actions/download-artifact@v3
       with:


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

The ci-wheels still had references to master rather than main and so was not pushing to Test-PyPI after merging PR's.
There were also another couple of places master has been changed to main. 

---
