### PR TITLE
Testing methods to upload and download all artifacts

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: pypi-sdist
+        merge-multiple: true
         path: ${{ github.workspace }}/dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1
@@ -129,7 +129,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: pypi-sdist
+        merge-multiple: true
         path: ${{ github.workspace }}/dist
 
     - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -91,12 +91,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: pypi-sdist
-        path: ${{ github.workspace }}/dist
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: pypi-**-artifact
+        merge-multiple: true
         path: ${{ github.workspace }}/dist
 
     - shell: bash

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -94,6 +94,11 @@ jobs:
         name: pypi-sdist
         path: ${{ github.workspace }}/dist
 
+    - uses: actions/download-artifact@v4
+      with:
+        name: pypi-**-artifact
+        path: ${{ github.workspace }}/dist
+
     - shell: bash
       run: |
         ls -l ${{ github.workspace }}/dist


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

After pushing up and merging #184 it has become apparent that since the artifacts are no longer all able to be put in the same place upon creation we must instead download them all to that place after they are made. So that they then can all be uploaded.

---