### PR TITLE
add import for np.import_array

### DIFF
--- a/src/stratify/_conservative.pyx
+++ b/src/stratify/_conservative.pyx
@@ -1,6 +1,9 @@
 import numpy as np
 cimport numpy as np
 
+# Must be called to use C-API
+np.import_array()
+
 
 cdef calculate_weights(np.ndarray[np.float64_t, ndim=2] src_point,
                        np.ndarray[np.float64_t, ndim=2] tgt_point):


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->


---

After the failing CI for #238 and #239. We found that we need to do `numpy.import_array()` when doing `cimport numpy as np`.

https://numpy.org/doc/stable/reference/c-api/array.html#c.import_array