### PR TITLE
add_numpy_array_import

### DIFF
--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools-scm
 
 # Core dependencies.
-  - numpy>=1.21
+  - numpy==1.26.4
   - cython
 
 # Optional dependencies.

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools-scm
 
 # Core dependencies.
-  - numpy>=1.21
+  - numpy==1.26.4
   - cython
 
 # Optional dependencies.

--- a/requirements/py39.yml
+++ b/requirements/py39.yml
@@ -11,7 +11,7 @@ dependencies:
   - setuptools-scm
 
 # Core dependencies.
-  - numpy>=1.21
+  - numpy==1.26.4
   - cython
 
 # Optional dependencies.

--- a/requirements/pypi-core.txt
+++ b/requirements/pypi-core.txt
@@ -1,3 +1,3 @@
 Cython
 dask[array]
-numpy>=1.21
+numpy==1.26.4

--- a/src/stratify/_conservative.pyx
+++ b/src/stratify/_conservative.pyx
@@ -1,6 +1,8 @@
 import numpy as np
 cimport numpy as np
 
+# Must be called to use the C-API with Numpy.
+np.import_array()
 
 cdef calculate_weights(np.ndarray[np.float64_t, ndim=2] src_point,
                        np.ndarray[np.float64_t, ndim=2] tgt_point):

--- a/src/stratify/_vinterp.pyx
+++ b/src/stratify/_vinterp.pyx
@@ -10,6 +10,8 @@ import numpy as np
 cimport cython
 cimport numpy as np
 
+# Must be called to use the C-API with Numpy.
+np.import_array()
 
 cdef extern from "numpy/npy_math.h" nogil:
     bint isnan "npy_isnan"(long double)


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->


---

After the failing CI for https://github.com/SciTools/python-stratify/pull/238 and https://github.com/SciTools/python-stratify/pull/239. We found that we need to do numpy.import_array() when doing cimport numpy as np.

https://numpy.org/doc/stable/reference/c-api/array.html#c.import_array