### PR TITLE
pep639: setuptools license and license-files fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 requires = [
   "Cython",
   "numpy>=2",
-  "setuptools>=61",
-  "setuptools_scm[toml]>=7",
+  "setuptools>=77.0.3",
+  "setuptools_scm[toml]>=8",
   "wheel",
 ]
 # Defined by PEP 517
@@ -17,7 +17,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Unix",
@@ -44,7 +43,8 @@ keywords = [
     "python",
     "ocean-science",
 ]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 name = "stratify"
 requires-python = ">=3.10"
 
@@ -53,7 +53,6 @@ Code = "https://github.com/SciTools-incubator/python-stratify"
 Issues = "https://github.com/SciTools-incubator/python-stratify/issues"
 
 [tool.setuptools]
-license-files = ["LICENSE"]
 zip-safe = false
 
 [tool.setuptools.dynamic]

--- a/requirements/py310.yml
+++ b/requirements/py310.yml
@@ -7,8 +7,8 @@ dependencies:
   - python=3.10
 
 # Setup dependencies.
-  - setuptools
-  - setuptools-scm
+  - setuptools>=77.0.3
+  - setuptools-scm>=8
 
 # Core dependencies.
   - numpy>=2

--- a/requirements/py311.yml
+++ b/requirements/py311.yml
@@ -7,8 +7,8 @@ dependencies:
   - python=3.11
 
 # Setup dependencies.
-  - setuptools
-  - setuptools-scm
+  - setuptools>=77.0.3
+  - setuptools-scm>=8
 
 # Core dependencies.
   - numpy>=2

--- a/requirements/py312.yml
+++ b/requirements/py312.yml
@@ -7,8 +7,8 @@ dependencies:
   - python=3.12
 
 # Setup dependencies.
-  - setuptools
-  - setuptools-scm
+  - setuptools>=77.0.3
+  - setuptools-scm>=8
 
 # Core dependencies.
   - numpy>=2


### PR DESCRIPTION
## 🚀 Pull Request

### Description
<!-- Provide a clear description about your awesome pull request -->
<!-- Tell us all about your new feature, improvement, or bug fix -->

This pull-request mops up some tech debt to comply with [PEP639](https://peps.python.org/pep-0639/) for `setuptools`, also see [license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files).

Additionally avoids the following `setuptools` deprecation warning:
```
!!
          ********************************************************************************
          Please consider removing the following classifiers in favor of a SPDX license expression:
          License :: OSI Approved :: BSD License
          See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
          ********************************************************************************
!!
```
See [Deprecated license classifiers](https://peps.python.org/pep-0639/#deprecate-license-classifiers).

---
